### PR TITLE
connection heartbeat is now configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
-All notable changes to `:package_name` will be documented in this file.
+All notable changes to `laravel-rabbitmq-communication` will be documented in this file.
+
+## v1.4.0 - 2023-07-19
+
+- specify hearbeat for connection in env

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -2,7 +2,7 @@
 
 return [
     /** -----------------------------------------------
-     * connections settings
+     * connection settings
      */
     'host' => env('RABBITMQ_HOST', '127.0.0.1'),
     'port' => env('RABBITMQ_PORT', 5672),

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -1,11 +1,15 @@
 <?php
 
 return [
+    /** -----------------------------------------------
+     * connections settings
+     */
     'host' => env('RABBITMQ_HOST', '127.0.0.1'),
     'port' => env('RABBITMQ_PORT', 5672),
     'user' => env('RABBITMQ_USER', 'guest'),
     'password' => env('RABBITMQ_PASSWORD', 'guest'),
     'vhost' => env('RABBITMQ_VHOST', '/'),
+    'heartbeat' => env('RABBITMQ_HEARTBEAT', 0),
 
     'event-consumers' => [
 //        [

--- a/src/RabbitMQ.php
+++ b/src/RabbitMQ.php
@@ -14,11 +14,12 @@ class RabbitMQ
     public function __construct()
     {
         $this->connection = new AMQPStreamConnection(
-            config('rabbitmq.host'),
-            config('rabbitmq.port'),
-            config('rabbitmq.user'),
-            config('rabbitmq.password'),
-            config('rabbitmq.vhost')
+            host: config('rabbitmq.host'),
+            port: config('rabbitmq.port'),
+            user: config('rabbitmq.user'),
+            password: config('rabbitmq.password'),
+            vhost: config('rabbitmq.vhost'),
+            heartbeat: config('rabbitmq.heartbeat', 0),
         );
 
         $this->channel = $this->connection->channel();


### PR DESCRIPTION
It is recommended not to deactivate the heartbeat. It can cause a connection be closed because of network errors silently.

check:
*  https://www.rabbitmq.com/heartbeats.html
* https://github.com/rabbitmq/rabbitmq-java-client/discussions/1019