### PR TITLE
[FEATURE] Upgrade package for Laravel 11 and PHP 8.1/8.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,20 +26,20 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/contracts": "^10",
+        "php": "^8.1 || ^8.2",
+        "illuminate/contracts": "^10.0 || ^11.0",
         "php-amqplib/php-amqplib": "^3.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "nunomaduro/collision": "^6",
+        "nunomaduro/collision": "^7",
         "nunomaduro/larastan": "^2.0",
-        "orchestra/testbench": "^8",
-        "pestphp/pest": "^1.21",
+        "orchestra/testbench": "^8.0 || ^9.0",
+        "pestphp/pest": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5 || ^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Allow `illuminate/contracts` ^10.0 || ^11.0 for Laravel 11 support
- Expand PHP version support to ^8.1 || ^8.2
- Upgrade Pest to v2 and Collision to v7 for test compatibility
- Allow Orchestra Testbench ^8.0 || ^9.0 to support both PHP versions
- Update PHPUnit to support ^9.5 || ^10.0